### PR TITLE
Fix problems in the race condition handling logic in LockJob

### DIFF
--- a/que_test.go
+++ b/que_test.go
@@ -6,13 +6,15 @@ import (
 	"github.com/jackc/pgx"
 )
 
-func openTestClient(t testing.TB) *Client {
+var testConnConfig = pgx.ConnConfig{
+	Host:     "localhost",
+	Database: "que-go-test",
+}
+
+func openTestClientMaxConns(t testing.TB, maxConnections int) *Client {
 	connPoolConfig := pgx.ConnPoolConfig{
-		ConnConfig: pgx.ConnConfig{
-			Host:     "localhost",
-			Database: "que-go-test",
-		},
-		MaxConnections: 5,
+		ConnConfig: testConnConfig,
+		MaxConnections: maxConnections,
 		AfterConnect:   PrepareStatements,
 	}
 	pool, err := pgx.NewConnPool(connPoolConfig)
@@ -20,6 +22,10 @@ func openTestClient(t testing.TB) *Client {
 		t.Fatal(err)
 	}
 	return NewClient(pool)
+}
+
+func openTestClient(t testing.TB) *Client {
+	return openTestClientMaxConns(t, 5)
 }
 
 func truncateAndClose(pool *pgx.ConnPool) {


### PR DESCRIPTION
Here's a fix for the problem I talked about in #2.  I also noticed another problem where the code was leaking locks, which I fixed in the same commit, since I didn't consider the intermediate state worth exposing.

For posterity, I wrote [this test code](https://gist.github.com/johto/c247af6e8ddcb7f68701) to test the race condition handling, but I think it's perhaps a bit too crazy to be executed in "go test".  We could includ it as a disabled-by-default test, I guess?

I also didn't do anything to try and prevent the loop from running forever.  I didn't really consider it necessary, but I'm willing to be persuaded the other way.