### PR TITLE
Fix pgx dependency to v2

### DIFF
--- a/que.go
+++ b/que.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx"
+	pgx "gopkg.in/jackc/pgx.v2"
 )
 
 // Job is a single unit of work for Que to perform.


### PR DESCRIPTION
Fix dependency of pgx to v2.

Can be closed when https://github.com/bgentry/que-go/pull/16 gets merged.