### PR TITLE
Add a missing conn release to avoid deadlock

### DIFF
--- a/que.go
+++ b/que.go
@@ -278,6 +278,7 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			return nil, err
 		}
 	}
+	c.pool.Release(conn)
 	return nil, ErrAgain
 }
 


### PR DESCRIPTION
I believe the missing release of the connection can cause deadlock under certain conditions: the pool exhausts available connections when you hit the lock race condition`maxLockJobAttempts` times in a row, and all further `LockJob` attempts hang on `c.pool.Acquire()`.

I had a look at adding a test for the branch where `LockJob` returns `ErrAgain`, but it's tricky triggering that race condition.  Any advice on doing so would be welcome.