### PR TITLE
Added options for worker and worker pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ Please see the [godocs][godoc] for more info and examples.
 [ruby-que]: https://github.com/chanks/que
 [pgx]: https://github.com/jackc/pgx
 [pq]: https://github.com/lib/pq
+
+## Running tests
+
+The package is bundled with `docker-compose.yml` for running integration tests
+that use PostgreSQL. Run the DB in the container and initialize schema:
+
+```
+$ docker-compose up -d
+$ docker-compose exec -T postgres psql que-go-test -U que-go-test < schema.sql
+```
+
+Now you're ready to run tests:
+
+```
+$ go test
+```
+
+After finishing with tests bring the environment down with:
+
+```
+$ docker-compose down -v
+```

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package que-go is a fully interoperable Golang port of Chris Hanks' Ruby Que
+Package que is a fully interoperable Golang port of Chris Hanks' Ruby Que
 queueing library for PostgreSQL. Que uses PostgreSQL's advisory locks
 for speed and reliability. See the original Que documentation for more details:
 https://github.com/chanks/que

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+
+  postgres:
+    image: postgres:9.6-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: que-go-test
+      POSTGRES_USER: que-go-test
+      POSTGRES_PASSWORD: que-go-test
+      PGPASSWORD: que-go-test

--- a/que.go
+++ b/que.go
@@ -202,7 +202,7 @@ type queryable interface {
 // avoid looping forever in case something is wrong.
 const maxLockJobAttempts = 10
 
-// Returned by LockJob if a job could not be retrieved from the queue after
+// ErrAgain returned by LockJob if a job could not be retrieved from the queue after
 // several attempts because of concurrently running transactions.  This error
 // should not be returned unless the queue is under extremely heavy
 // concurrency.
@@ -291,6 +291,7 @@ var preparedStatements = map[string]string{
 	"que_unlock_job":  sqlUnlockJob,
 }
 
+// PrepareStatements creates a prepared statements within a connection to use for internal routines.
 func PrepareStatements(conn *pgx.Conn) error {
 	for name, sql := range preparedStatements {
 		if _, err := conn.Prepare(name, sql); err != nil {

--- a/que_test.go
+++ b/que_test.go
@@ -9,6 +9,8 @@ import (
 var testConnConfig = pgx.ConnConfig{
 	Host:     "localhost",
 	Database: "que-go-test",
+	User:     "que-go-test",
+	Password: "que-go-test",
 }
 
 func openTestClientMaxConns(t testing.TB, maxConnections int) *Client {

--- a/worker.go
+++ b/worker.go
@@ -92,6 +92,7 @@ func (w *Worker) Work() {
 	}
 }
 
+// WorkOne tries to consume single message from the queue.
 func (w *Worker) WorkOne() (didWork bool) {
 	j, err := w.c.LockJob(w.Queue)
 	if err != nil {

--- a/worker_option.go
+++ b/worker_option.go
@@ -1,0 +1,37 @@
+package que
+
+import "time"
+
+// WorkerOption defines a type that allows to set worker properties during the build-time.
+type WorkerOption func(*Worker)
+
+// WorkerPoolOption defines a type that allows to set worker pool properties during the build-time.
+type WorkerPoolOption func(pool *WorkerPool)
+
+// WakeInterval overrides default wake interval with the given value.
+func WakeInterval(d time.Duration) WorkerOption {
+	return func(w *Worker) {
+		w.Interval = d
+	}
+}
+
+// WorkerQueue overrides default worker queue name with the given value.
+func WorkerQueue(queue string) WorkerOption {
+	return func(w *Worker) {
+		w.Queue = queue
+	}
+}
+
+// PoolWakeInterval overrides default wake interval with the given value.
+func PoolWakeInterval(d time.Duration) WorkerPoolOption {
+	return func(w *WorkerPool) {
+		w.Interval = d
+	}
+}
+
+// PoolWorkerQueue overrides default worker queue name with the given value.
+func PoolWorkerQueue(queue string) WorkerPoolOption {
+	return func(w *WorkerPool) {
+		w.Queue = queue
+	}
+}

--- a/worker_option_test.go
+++ b/worker_option_test.go
@@ -1,0 +1,95 @@
+package que
+
+import (
+	"testing"
+	"time"
+	"os"
+)
+
+func TestWakeInterval(t *testing.T) {
+	c := openTestClient(t)
+	defer truncateAndClose(c.pool)
+
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			return nil
+		},
+	}
+
+	workerWithDefaultInterval := NewWorker(c, wm)
+	if workerWithDefaultInterval.Interval != defaultWakeInterval {
+		t.Fatal("Worker interval has value other than the default one")
+	}
+
+	customInterval := 12345 * time.Millisecond
+	workerWithCustomInterval := NewWorker(c, wm, WakeInterval(customInterval))
+	if workerWithCustomInterval.Interval != customInterval {
+		t.Fatal("Worker interval has value other than custom one")
+	}
+}
+
+func TestWorkerQueue(t *testing.T) {
+	c := openTestClient(t)
+	defer truncateAndClose(c.pool)
+
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			return nil
+		},
+	}
+
+	workerWithDefaultQueue := NewWorker(c, wm)
+	if workerWithDefaultQueue.Queue != os.Getenv("QUE_QUEUE") {
+		t.Fatal("Worker queue has value other than the default one")
+	}
+
+	customQueue := "fooBarBaz"
+	workerWithCustomQueue := NewWorker(c, wm, WorkerQueue(customQueue))
+	if workerWithCustomQueue.Queue != customQueue {
+		t.Fatal("Worker interval has value other than custom one")
+	}
+}
+
+func TestPoolWakeInterval(t *testing.T) {
+	c := openTestClient(t)
+	defer truncateAndClose(c.pool)
+
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			return nil
+		},
+	}
+
+	workerPoolWithDefaultInterval := NewWorkerPool(c, wm, 2)
+	if workerPoolWithDefaultInterval.Interval != defaultWakeInterval {
+		t.Fatal("WorkerPool interval has value other than the default one")
+	}
+
+	customInterval := 12345 * time.Millisecond
+	workerPoolWithCustomInterval := NewWorkerPool(c, wm, 2, PoolWakeInterval(customInterval))
+	if workerPoolWithCustomInterval.Interval != customInterval {
+		t.Fatal("WorkerPool interval has value other than custom one")
+	}
+}
+
+func TestPoolWorkerQueue(t *testing.T) {
+	c := openTestClient(t)
+	defer truncateAndClose(c.pool)
+
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			return nil
+		},
+	}
+
+	workerPoolWithDefaultQueue := NewWorkerPool(c, wm, 2)
+	if workerPoolWithDefaultQueue.Queue != "" {
+		t.Fatal("WorkerPool queue has value other than the default one")
+	}
+
+	customQueue := "fooBarBaz"
+	workerPoolWithCustomQueue := NewWorkerPool(c, wm, 2, PoolWorkerQueue(customQueue))
+	if workerPoolWithCustomQueue.Queue != customQueue {
+		t.Fatal("WorkerPool interval has value other than custom one")
+	}
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -151,7 +151,6 @@ func TestWorkerWorkRescuesPanic(t *testing.T) {
 		"MyJob": func(j *Job) error {
 			called++
 			panic("the panic msg")
-			return nil
 		},
 	}
 	w := NewWorker(c, wm)


### PR DESCRIPTION
I'm using this library to implement Outbox pattern for my project - every time I want to publish a message to the queue (RabbitMQ in my case) I want to store it to reliable storage fist - store it to DB in the same transaction that performs the main logic. In this case I can be sure that either both logic applied and message (or messages) is posted or everything is rolled back.

In this PR I added `WorkerOption` and `WorkerPoolOption` to allow setting `Interval` and `Queue` properties in more golang ideomatic way instead of env variables (global state) or exposing public properties, keeping full BC - so both old and new approches will work.

Additionally I added `docker-compose` file and instructions on running tests in PostgreSQL runnig in Docker and fixed couple minor issue found by vet and lint - https://goreportcard.com/report/github.com/bgentry/que-go