### PR TITLE
Configurable delay

### DIFF
--- a/work_test.go
+++ b/work_test.go
@@ -252,8 +252,13 @@ func TestLockJobAdvisoryRace(t *testing.T) {
 		for {
 			var waiting bool
 			err := conn.QueryRow(`SELECT wait_event is not null from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
+
+			// This is a fallback. In PostgreSQL version 9.6 'waiting' was replaced with 'wait_event'.
 			if err != nil {
-				panic(err)
+				err := conn.QueryRow(`SELECT waiting from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
+				if err != nil {
+					panic(err)
+				}
 			}
 
 			if waiting {


### PR DESCRIPTION
I am using this library and needed to have some testing for a Job that errors several times until it finally fails. For this I implemented a configurable delay (as requested in the TODO 👍 ).

Additionally, older versions of PostgreSQL would fail tests because the column `wait_event` on table `pg_stat_activity` was a boolean column named `waiting` prior to PostgreSQL 9.6. I added a fallback for this.

Thank you and let me know what you think.