### PR TITLE
Use pgtype package instead of subpackage from pgx v3

### DIFF
--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/pgtype"
+	"github.com/jackc/pgtype"
 )
 
 func TestEnqueueOnlyType(t *testing.T) {

--- a/que.go
+++ b/que.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 )
 
 // Job is a single unit of work for Que to perform.

--- a/work_test.go
+++ b/work_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 )
 
 func TestLockJob(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/pgtype"
+	"github.com/jackc/pgtype"
 )
 
 func init() {


### PR DESCRIPTION
Hi.

First of all thank you for this package - I find it very useful and easy to use.

Recently I started migration of my project to the latest pgx/v4 and this package supports only pgx/v3. I can help with adding v4 (keeping v3 functional) if you're interested. This PR is the first small step toward v4 - it replaces `github.com/jackc/pgx/pgtype` that used to be subpackage in v3 with `github.com/jackc/pgtype` that is the same package but extracted to standalone repo in v4.

PS: what do you think about adding linting and tests to PRs using Github Actions? I can help with this as well if you do not have time to take care of the project.