### PR TITLE
Fetch last_error when locking a job

### DIFF
--- a/que.go
+++ b/que.go
@@ -239,6 +239,7 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			&j.Type,
 			&j.Args,
 			&j.ErrorCount,
+			&j.LastError,
 		)
 		if err != nil {
 			c.pool.Release(conn)

--- a/sql.go
+++ b/sql.go
@@ -54,7 +54,7 @@ WITH RECURSIVE jobs AS (
     ) AS t1
   )
 )
-SELECT queue, priority, run_at, job_id, job_class, args, error_count
+SELECT queue, priority, run_at, job_id, job_class, args, error_count, last_error
 FROM jobs
 WHERE locked
 LIMIT 1


### PR DESCRIPTION
Without this, the job LastError attribute is always empty when processing.