### PR TITLE
fix(Webhooks): Broken transactional logic in go Queue

### DIFF
--- a/que.go
+++ b/que.go
@@ -61,10 +61,6 @@ var defaultDelayFunction = func(errorCount int32) int {
 	return intPow(int(errorCount), 4) + 3
 }
 
-var defaultDelayFunction = func(errorCount int32) int {
-	return intPow(int(errorCount), 4) + 3
-}
-
 // Conn returns the pgx connection that this job is locked to. You may initiate
 // transactions on this connection or use it as you please until you call
 // Done(). At that point, this conn will be returned to the pool and it is

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE que_jobs
+CREATE TABLE IF NOT EXISTS que_jobs
 (
   priority    smallint    NOT NULL DEFAULT 100,
   run_at      timestamptz NOT NULL DEFAULT now(),


### PR DESCRIPTION
## Problem
The issue occurs in interaction between our database maintenance tasks and the queue within the Talon service that is responsible for webhooks delivery. Specifically, the issue arises when the Talon service has a backlog of webhooks during database maintenance tasks. The primary issue we're facing is the incompatibility between the talon-service's transactional flow and the current approach of the Go Queue, which maintains its own pool of database connections.

## Solution
Modify the Go Queue module to accept a talon-service transaction as a parameter in the Enqueue method.


