### PR TITLE
chore(Enqueue): Enqueue should use pgx v5 transation

### DIFF
--- a/que.go
+++ b/que.go
@@ -61,10 +61,6 @@ var defaultDelayFunction = func(errorCount int32) int {
 	return intPow(int(errorCount), 4) + 3
 }
 
-var defaultDelayFunction = func(errorCount int32) int {
-	return intPow(int(errorCount), 4) + 3
-}
-
 // Conn returns the pgx connection that this job is locked to. You may initiate
 // transactions on this connection or use it as you please until you call
 // Done(). At that point, this conn will be returned to the pool and it is

--- a/que.go
+++ b/que.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jackc/pgx"
 	"github.com/jackc/pgx/pgtype"
-	pgxV4 "github.com/jackc/pgx/v4"
+	pgxV5 "github.com/jackc/pgx/v5"
 )
 
 // Job is a single unit of work for Que to perform.
@@ -158,7 +158,7 @@ func NewClient(pool *pgx.ConnPool) *Client {
 var ErrMissingType = errors.New("job type must be specified")
 
 // Enqueue method appends a job to the queue adhering to the transactional flow of the Talon service.
-func (c *Client) Enqueue(j *Job, txn pgxV4.Tx) error {
+func (c *Client) Enqueue(j *Job, txn pgxV5.Tx) error {
 	return execEnqueue(j, txn)
 }
 
@@ -168,11 +168,11 @@ func (c *Client) Enqueue(j *Job, txn pgxV4.Tx) error {
 //
 // It is the caller's responsibility to Commit or Rollback the transaction after
 // this function is called.
-func (c *Client) EnqueueInTx(j *Job, txn pgxV4.Tx) error {
+func (c *Client) EnqueueInTx(j *Job, txn pgxV5.Tx) error {
 	return execEnqueue(j, txn)
 }
 
-func execEnqueue(j *Job, txn pgxV4.Tx) error {
+func execEnqueue(j *Job, txn pgxV5.Tx) error {
 	if j.Type == "" {
 		return ErrMissingType
 	}

--- a/que.go
+++ b/que.go
@@ -209,7 +209,7 @@ func execEnqueue(j *Job, txn pgxV4.Tx) error {
 		args.Status = pgtype.Present
 	}
 
-	_, err := txn.Exec(context.Background(), "que_insert_job", queue, priority, runAt, j.Type, args)
+	_, err := txn.Exec(context.Background(), sqlInsertJob, queue, priority, runAt, j.Type, args)
 	return err
 }
 

--- a/work_test.go
+++ b/work_test.go
@@ -252,8 +252,13 @@ func TestLockJobAdvisoryRace(t *testing.T) {
 		for {
 			var waiting bool
 			err := conn.QueryRow(`SELECT wait_event is not null from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
+
+			// This is a fallback. In PostgreSQL version 9.6 'waiting' was replaced with 'wait_event'.
 			if err != nil {
-				panic(err)
+				err := conn.QueryRow(`SELECT waiting from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
+				if err != nil {
+					panic(err)
+				}
 			}
 
 			if waiting {

--- a/worker.go
+++ b/worker.go
@@ -117,7 +117,8 @@ func (w *Worker) WorkOne() (didWork bool) {
 	if err = j.Delete(); err != nil {
 		log.Printf("attempting to delete job %d: %v", j.ID, err)
 	}
-	log.Printf("event=job_worked job_id=%d job_type=%s", j.ID, j.Type)
+	// This is not the ERROR-level log, but rather just INFO-level. We just disable it, because it's too noisy.
+	//log.Printf("event=job_worked job_id=%d job_type=%s", j.ID, j.Type)
 	return
 }
 


### PR DESCRIPTION
### Problem

We need to use pgx v5 in our main application, but the `Enqueue` method takes a `Tx` object from pgz v4.

### Solution

Update the `Enqueue` method so it takes `Tx` from pgx v5.